### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Latest Version](https://pypip.in/version/pydiq/badge.svg)](https://pypi.python.org/pypi/pydiq/)
-[![License](https://pypip.in/license/pydiq/badge.svg)](https://pypi.python.org/pypi/pydiq/)
+[![Latest Version](https://img.shields.io/pypi/v/pydiq.svg)](https://pypi.python.org/pypi/pydiq/)
+[![License](https://img.shields.io/pypi/l/pydiq.svg)](https://pypi.python.org/pypi/pydiq/)
 [![DOI](https://zenodo.org/badge/3862/janpipek/pydiq.png)](http://dx.doi.org/10.5281/zenodo.11480)
 
 pydiq


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pydiq))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pydiq`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.